### PR TITLE
Saving path handles slash between urlName and the rest

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/prometheus/config/PrometheusConfiguration.java
@@ -74,9 +74,11 @@ public class PrometheusConfiguration extends GlobalConfiguration {
     }
 
     public void setPath(String path) {
-        urlName = path.split("/")[0];
-        List<String> pathParts = Arrays.asList(path.split("/"));
-        additionalPath = (pathParts.size() > 1 ? "/" : "") + StringUtils.join(pathParts.subList(1, pathParts.size()), "/");
+        // remove leading slash if it exists.
+        path = path.startsWith("/") ? path.substring(1) : path;
+        List<String> pathParts = Arrays.asList(path.split("/", 2));
+        urlName = pathParts.get(0);
+        additionalPath = (pathParts.size() > 1) ? pathParts.get(1) : "";
     }
 
     public String getDefaultNamespace() {


### PR DESCRIPTION
setPath needs to separate between urlName and additionalPath for a
user provided URL or path. This is so the getUrlName from Action is
handled properly.

This commit sets the content before the first slash as the urlName
and the rest of the string as additionalPath. This removes both
the trailing slash from urlName and the leading slash on addPath.